### PR TITLE
admin-only download option

### DIFF
--- a/activate.php
+++ b/activate.php
@@ -56,6 +56,9 @@ $defaults = array(
 
 	// Entity title
 	'kaltura_entity_title' => 'Videos',
+	
+	// admin video download
+	'admin_only_download' => 'no'
 );
 
 // Set default config values

--- a/languages/en.php
+++ b/languages/en.php
@@ -94,6 +94,8 @@ return array(
 	'simplekaltura:admin:uiconfid' => 'KSU uiConfId',
 	'simplekaltura:admin:uiconfiddesc' => 'See: http://knowledge.kaltura.com/kaltura-simple-uploader-ksu-website-integration-guide',
 	'simplekaltura:admin:allownonpublicembed' => 'Allow non-public video embeds',
+	'simplekaltura:admin:additional_settings' => 'Additional Settings',
+	'simplekaltura:admin:admin_only_download' => "Restrict video downloads to admin only?",
 
 	// River
 	'river:create:object:simplekaltura_video' => '%s uploaded a Video titled %s',

--- a/start.php
+++ b/start.php
@@ -221,17 +221,20 @@ function simplekaltura_setup_entity_menu($hook, $type, $value, $params) {
 
 	if (elgg_instanceof($entity, 'object', 'simplekaltura_video')) {
 		// Add download link if we have a download url
+		$admin_download = elgg_get_plugin_setting('admin_only_download', 'simplekaltura');
 		$download_url = $entity->downloadUrl;
 		if ($download_url) {
-			$options = array(
-				'name' => 'download_video',
-				'text' => elgg_echo('simplekaltura:label:download'),
-				'title' => 'download_video',
-				'href' => $download_url,
-				'priority' => 200,
-			);
+			if ($admin_download != 'yes' || elgg_is_admin_logged_in()) {
+				$options = array(
+					'name' => 'download_video',
+					'text' => elgg_echo('simplekaltura:label:download'),
+					'title' => 'download_video',
+					'href' => $download_url,
+					'priority' => 200,
+				);
 
-			$value[] = ElggMenuItem::factory($options);
+				$value[] = ElggMenuItem::factory($options);
+			}
 		}
 
 		// feature link

--- a/views/default/plugins/simplekaltura/settings.php
+++ b/views/default/plugins/simplekaltura/settings.php
@@ -72,6 +72,9 @@ $upload_max = $plugin->kaltura_upload_max;
 // Entity title
 $entity_title = $plugin->kaltura_entity_title;
 
+// Admin only download
+$admin_only_download = $plugin->admin_only_download;
+
 /************** Site Configuration Module **************/
 $site_config_label = elgg_echo('simplekaltura:admin:siteconfig');
 
@@ -382,6 +385,28 @@ $upload_body = <<<HTML
 HTML;
 
 echo elgg_view_module('inline', $upload_label, $upload_body);
+
+
+/************** Additional Settings **********/
+$additional_settings_label = elgg_echo('simplekaltura:admin:additional_settings');
+$admin_download_label = elgg_echo('simplekaltura:admin:admin_only_download');
+$admin_download_input = elgg_view('input/dropdown', array(
+	'name' => 'params[admin_only_download]',
+	'value' => $admin_only_download ? $admin_only_download : 'no',
+	'options_values' => array(
+		'yes' => elgg_echo('option:yes'),
+		'no' => elgg_echo('option:no')
+	)
+));
+
+$additional_settings_body = <<<HTML
+	<div>
+		<label>$admin_download_label</label>
+		$admin_download_input
+	</div>
+HTML;
+
+echo elgg_view_module('inline', $additional_settings_label, $additional_settings_body);
 
 
 if (simplekaltura_migration_check()) {


### PR DESCRIPTION
This PR adds a plugin setting to restrict the download link to admin-only
The default behavior is unchanged.